### PR TITLE
Output correct repository type after push operation

### DIFF
--- a/src/PushCommand.php
+++ b/src/PushCommand.php
@@ -140,7 +140,7 @@ EOT
             $provider->sendFile($fileName);
 
             $this->getIO()
-                ->write('Archive correctly pushed to the ' . ucfirst($input->getOption('type')) . ' server');
+                ->write('Archive correctly pushed to the ' . ucfirst($this->configuration->getType()) . ' server');
         } finally {
             $this->getIO()
                 ->write(

--- a/src/PushCommand.php
+++ b/src/PushCommand.php
@@ -140,7 +140,7 @@ EOT
             $provider->sendFile($fileName);
 
             $this->getIO()
-                ->write('Archive correctly pushed to the Nexus server');
+                ->write('Archive correctly pushed to the ' . ucfirst($input->getOption('type')) . ' server');
         } finally {
             $this->getIO()
                 ->write(


### PR DESCRIPTION
Even when pushing to Artifactory the message printed is always "Archive correctly pushed to the Nexus server", this should do the trick I guess.