### PR TITLE
Support Symfony 6.0

### DIFF
--- a/.github/workflows/testing-and-cs.yaml
+++ b/.github/workflows/testing-and-cs.yaml
@@ -25,7 +25,7 @@ jobs:
       matrix:
         php: [7.2, 7.3, 7.4, 8.0, 8.1]
         composer: ["1.10", 2.0, 2.1, 2.2]
-        symfony: [^3.0, ^4.0, ^5.0, ^6.0]
+        symfony: [^4.0, ^5.0, ^6.0]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2

--- a/.github/workflows/testing-and-cs.yaml
+++ b/.github/workflows/testing-and-cs.yaml
@@ -23,9 +23,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [7.2, 7.3, 7.4, 8.0]
-        composer: ["1.10", 2.0, 2.1]
-        symfony: [^3.0, ^4.0, ^5.0]
+        php: [7.2, 7.3, 7.4, 8.0, 8.1]
+        composer: ["1.10", 2.0, 2.1, 2.2]
+        symfony: [^3.0, ^4.0, ^5.0, ^6.0]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2

--- a/.github/workflows/testing-and-cs.yaml
+++ b/.github/workflows/testing-and-cs.yaml
@@ -17,7 +17,7 @@ jobs:
         with:
           args: "vendor/bin/php-cs-fixer fix src --dry-run"
 
-  PHPUnit:
+  PHPUnit-Symfony45:
     name: PHPUnit testing
     runs-on: ubuntu-latest
     strategy:
@@ -25,7 +25,28 @@ jobs:
       matrix:
         php: [7.2, 7.3, 7.4, 8.0, 8.1]
         composer: ["1.10", 2.0, 2.1, 2.2]
-        symfony: [^4.0, ^5.0, ^6.0]
+        symfony: [^4.0, ^5.0]
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      - name: 'Unit testing'
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          tools: composer:${{ matrix.composer }}
+      - run: composer install
+      - run: composer require "symfony/finder:${{ matrix.symfony }}" "symfony/filesystem:${{ matrix.symfony }}"
+      - run: composer update
+      - run: vendor/bin/phpunit tests
+  PHPUnit-Symfony6:
+    name: PHPUnit testing
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        php: [8.0, 8.1]
+        composer: [2.0, 2.1, 2.2]
+        symfony: [^6.0]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2

--- a/.github/workflows/testing-and-cs.yaml
+++ b/.github/workflows/testing-and-cs.yaml
@@ -62,7 +62,7 @@ jobs:
 
   BuildDone:
     name: PHP full build
-    needs: [PHPCS, PHPUnit]
+    needs: [PHPCS, PHPUnit-Symfony45, PHPUnit-Symfony6]
     runs-on: ubuntu-latest
     steps:
       - run: "echo build done"

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ composer.lock
 .idea/
 .phpunit.result.cache
 .php_cs.cache
+.php-cs-fixer.cache

--- a/composer.json
+++ b/composer.json
@@ -19,15 +19,15 @@
         "ext-zip": "*",
         "composer-plugin-api": "^1.1|^2.0",
         "guzzlehttp/guzzle": "^6.0|^7.0",
-        "symfony/finder": "^3.0|^4.0|^5.0",
-        "symfony/filesystem": "^3.0|^4.0|^5.0"
+        "symfony/finder": "^4.0|^5.0|^6.0",
+        "symfony/filesystem": "^4.0|^5.0|^6.0"
     },
     "extra": {
         "class": "Elendev\\ComposerPush\\Plugin"
     },
     "require-dev": {
-        "friendsofphp/php-cs-fixer": "^2.18",
-        "phpunit/phpunit": "^8 || ^9",
+        "friendsofphp/php-cs-fixer": "^3.4.0",
+        "phpunit/phpunit": "^8 || ^9 || ^10",
         "composer/composer": "^1.8 || ^2.0"
     },
     "replace": {

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -1,6 +1,5 @@
 <?php
 
-
 namespace Elendev\ComposerPush;
 
 use Composer\Composer;
@@ -29,7 +28,7 @@ class Configuration
      */
     private $io;
 
-    const PUSH_CFG_NAME = 'name';
+    public const PUSH_CFG_NAME = 'name';
 
     public function __construct(InputInterface $input, Composer $composer, IOInterface $io)
     {

--- a/src/InvalidConfigException.php
+++ b/src/InvalidConfigException.php
@@ -1,6 +1,5 @@
 <?php
 
-
 namespace Elendev\ComposerPush;
 
 class InvalidConfigException extends \LogicException

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -1,6 +1,5 @@
 <?php
 
-
 namespace Elendev\ComposerPush;
 
 use Composer\Composer;

--- a/src/PushCommand.php
+++ b/src/PushCommand.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elendev\ComposerPush;
 
 if (file_exists(dirname(__DIR__) . '/vendor/autoload.php')) {
@@ -25,15 +26,14 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class PushCommand extends BaseCommand
 {
-
     /**
      * @var Configuration
      */
     private $configuration;
 
-    const REPOSITORY = 'repository';
+    public const REPOSITORY = 'repository';
 
-    const PROVIDER_TYPES = [
+    public const PROVIDER_TYPES = [
         'nexus' => 'Elendev\ComposerPush\RepositoryProvider\NexusProvider',
         'artifactory' => 'Elendev\ComposerPush\RepositoryProvider\ArtifactoryProvider'
     ];

--- a/src/PushCommandProvider.php
+++ b/src/PushCommandProvider.php
@@ -1,6 +1,5 @@
 <?php
 
-
 namespace Elendev\ComposerPush;
 
 use Composer\Plugin\Capability\CommandProvider;

--- a/src/RepositoryProvider/AbstractProvider.php
+++ b/src/RepositoryProvider/AbstractProvider.php
@@ -1,6 +1,5 @@
 <?php
 
-
 namespace Elendev\ComposerPush\RepositoryProvider;
 
 use Composer\IO\IOInterface;

--- a/src/RepositoryProvider/ArtifactoryProvider.php
+++ b/src/RepositoryProvider/ArtifactoryProvider.php
@@ -1,6 +1,5 @@
 <?php
 
-
 namespace Elendev\ComposerPush\RepositoryProvider;
 
 class ArtifactoryProvider extends AbstractProvider

--- a/src/RepositoryProvider/NexusProvider.php
+++ b/src/RepositoryProvider/NexusProvider.php
@@ -1,6 +1,5 @@
 <?php
 
-
 namespace Elendev\ComposerPush\RepositoryProvider;
 
 class NexusProvider extends AbstractProvider

--- a/src/ZipArchiver.php
+++ b/src/ZipArchiver.php
@@ -1,6 +1,5 @@
 <?php
 
-
 namespace Elendev\ComposerPush;
 
 use Composer\IO\IOInterface;
@@ -10,7 +9,6 @@ use Symfony\Component\Finder\Finder;
 
 class ZipArchiver
 {
-
     /**
      * Archive the given directory in the $destination file
      *


### PR DESCRIPTION
This fixes #62 with a compatible set of composer requirements (Thankful for CS-Fixer 3.4.0!)

This also drops support for symfony 3. Which this package doesnt support anyways because of PHP version requirements.