### PR TITLE
Add Progress Bar to upload output

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,6 +30,11 @@
         "phpunit/phpunit": "^8 || ^9 || ^10",
         "composer/composer": "^1.8 ||  ^2.0"
     },
+    "scripts": {
+        "test": "phpunit tests",
+        "cs-fixer": "php-cs-fixer fix src"
+
+    },
     "replace": {
         "elendev/nexus-composer-push":  "*"
     },

--- a/src/PushCommand.php
+++ b/src/PushCommand.php
@@ -139,7 +139,7 @@ EOT
 
             $this->getIO()
                 ->write(
-                    'Pushing archive to server: ' . $provider->getUrl() . '...',
+                    'Pushing archive to URL: ' . $provider->getUrl() . '...',
                     true
                 );
 

--- a/src/PushCommand.php
+++ b/src/PushCommand.php
@@ -139,7 +139,7 @@ EOT
 
             $this->getIO()
                 ->write(
-                    'Execute the push for the URL ' . $provider->getUrl() . '...',
+                    'Pushing archive to server: ' . $provider->getUrl() . '...',
                     true
                 );
 

--- a/src/RepositoryProvider/ArtifactoryProvider.php
+++ b/src/RepositoryProvider/ArtifactoryProvider.php
@@ -39,7 +39,7 @@ class ArtifactoryProvider extends AbstractProvider
     {
         $options['debug'] = $this->getIO()->isVeryVerbose();
         $options['body'] = fopen($file, 'r');
-        $options['progress'] =$this->getProgressCallback();
+        $options['progress'] = $this->getProgressCallback();
         $url = $this->getUrl() . '.' . pathinfo($file, PATHINFO_EXTENSION) . '?properties=composer.version=' . $this->getConfiguration()->getVersion();
         $this->getClient()->request('PUT', $url, $options);
     }

--- a/src/RepositoryProvider/ArtifactoryProvider.php
+++ b/src/RepositoryProvider/ArtifactoryProvider.php
@@ -42,7 +42,7 @@ class ArtifactoryProvider extends AbstractProvider
 
         $io = $this->getIO();
 
-        if(method_exists($io, 'getProgressBar')) {
+        if (method_exists($io, 'getProgressBar')) {
             /** @var \Symfony\Component\Console\Helper\ProgressBar */
             $progress = $io->getProgressBar();
             $options['progress'] = function (

--- a/src/RepositoryProvider/ArtifactoryProvider.php
+++ b/src/RepositoryProvider/ArtifactoryProvider.php
@@ -39,38 +39,7 @@ class ArtifactoryProvider extends AbstractProvider
     {
         $options['debug'] = $this->getIO()->isVeryVerbose();
         $options['body'] = fopen($file, 'r');
-
-        $io = $this->getIO();
-
-        if (method_exists($io, 'getProgressBar')) {
-            /** @var \Symfony\Component\Console\Helper\ProgressBar */
-            $progress = $io->getProgressBar();
-            $options['progress'] = function (
-                $downloadTotal,
-                $downloadedBytes,
-                $uploadTotal,
-                $uploadedBytes
-            ) use ($progress) {
-                if ($uploadTotal === 0) {
-                    return;
-                }
-                if ($uploadedBytes === 0) {
-                    $progress->start(100);
-                    return;
-                }
-
-                if ($uploadedBytes === $uploadTotal) {
-                    if ($progress->getProgress() != 100) {
-                        $progress->finish();
-                        $this->getIO()->write('');
-                    }
-                    return;
-                }
-
-                $progress->setProgress(($uploadedBytes / $uploadTotal) * 100);
-            };
-        }
-
+        $options['progress'] =$this->getProgressCallback();
         $url = $this->getUrl() . '.' . pathinfo($file, PATHINFO_EXTENSION) . '?properties=composer.version=' . $this->getConfiguration()->getVersion();
         $this->getClient()->request('PUT', $url, $options);
     }

--- a/src/RepositoryProvider/ArtifactoryProvider.php
+++ b/src/RepositoryProvider/ArtifactoryProvider.php
@@ -49,7 +49,7 @@ class ArtifactoryProvider extends AbstractProvider
                 $downloadTotal,
                 $downloadedBytes,
                 $uploadTotal,
-                $uploadedBytes,
+                $uploadedBytes
             ) use ($progress) {
                 if ($uploadTotal === 0) {
                     return;

--- a/src/RepositoryProvider/NexusProvider.php
+++ b/src/RepositoryProvider/NexusProvider.php
@@ -66,7 +66,7 @@ class NexusProvider extends AbstractProvider
             $options['body'] = fopen($file, 'r');
         }
 
-        $options['progress'] =$this->getProgressCallback();
+        $options['progress'] = $this->getProgressCallback();
 
         $this->getClient()->request('PUT', $url, $options);
     }

--- a/src/RepositoryProvider/NexusProvider.php
+++ b/src/RepositoryProvider/NexusProvider.php
@@ -68,7 +68,7 @@ class NexusProvider extends AbstractProvider
 
         $io = $this->getIO();
 
-        if(method_exists($io, 'getProgressBar')) {
+        if (method_exists($io, 'getProgressBar')) {
             /** @var \Symfony\Component\Console\Helper\ProgressBar */
             $progress = $io->getProgressBar();
             $options['progress'] = function (

--- a/src/RepositoryProvider/NexusProvider.php
+++ b/src/RepositoryProvider/NexusProvider.php
@@ -66,36 +66,7 @@ class NexusProvider extends AbstractProvider
             $options['body'] = fopen($file, 'r');
         }
 
-        $io = $this->getIO();
-
-        if (method_exists($io, 'getProgressBar')) {
-            /** @var \Symfony\Component\Console\Helper\ProgressBar */
-            $progress = $io->getProgressBar();
-            $options['progress'] = function (
-                $downloadTotal,
-                $downloadedBytes,
-                $uploadTotal,
-                $uploadedBytes
-            ) use ($progress) {
-                if ($uploadTotal === 0) {
-                    return;
-                }
-                if ($uploadedBytes === 0) {
-                    $progress->start(100);
-                    return;
-                }
-
-                if ($uploadedBytes === $uploadTotal) {
-                    if ($progress->getProgress() != 100) {
-                        $progress->finish();
-                        $this->getIO()->write('');
-                    }
-                    return;
-                }
-
-                $progress->setProgress(($uploadedBytes / $uploadTotal) * 100);
-            };
-        }
+        $options['progress'] =$this->getProgressCallback();
 
         $this->getClient()->request('PUT', $url, $options);
     }

--- a/src/RepositoryProvider/NexusProvider.php
+++ b/src/RepositoryProvider/NexusProvider.php
@@ -75,7 +75,7 @@ class NexusProvider extends AbstractProvider
                 $downloadTotal,
                 $downloadedBytes,
                 $uploadTotal,
-                $uploadedBytes,
+                $uploadedBytes
             ) use ($progress) {
                 if ($uploadTotal === 0) {
                     return;


### PR DESCRIPTION
This utilizes the `getProgressBar` method of `Composer\IO\ConsoleIO` to display a progress bar during upload of packages

```
Execute the push for the URL <url>...
 100/100 [============================] 100%
Archive correctly pushed to the Nexus server
```