### PR TITLE
Fix not ignoring dot files

### DIFF
--- a/src/PushCommand.php
+++ b/src/PushCommand.php
@@ -132,6 +132,7 @@ EOT
                 $this->configuration->getVersion(),
                 $subdirectory,
                 $ignoredDirectories,
+                $input->getOption('keep-dot-files'),
                 $this->getIO()
             );
 

--- a/tests/ZipArchiverTest.php
+++ b/tests/ZipArchiverTest.php
@@ -39,6 +39,26 @@ class ZipArchiverTest extends TestCase
         $this->assertArchiveContainsFiles($this->generationPath, $expectedResult);
     }
 
+    /**
+     * @dataProvider zipArchiverProvider
+     */
+    public function testArchiveDirectoryWithDotFiles(string $directory, array $expectedResult, string $subdirectory = null, array $ignore = [])
+    {
+        $expectedResult[] = $subdirectory !== null ? $subdirectory . '/.foo/foo.txt' : '.foo/foo.txt';
+
+        ZipArchiver::archiveDirectory(
+            $directory,
+            $this->generationPath,
+            '0.0.1',
+            $subdirectory,
+            $ignore,
+            true
+        );
+
+
+        $this->assertArchiveContainsFiles($this->generationPath, $expectedResult);
+    }
+
     public function zipArchiverProvider() {
         return [
             [


### PR DESCRIPTION
The `--keep-dot-files` was being ignored and the archive was always keeping the dot files. Parameters were off by one.